### PR TITLE
error: impl Debug and Error traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ categories = ["Asynchronous", "Concurrency", "Rust patterns"]
 [dependencies]
 tokio = { version = "1.17.0", features = ["sync", "rt"] }
 async-trait = "0.1.53"
+thiserror = "1.0.31"

--- a/src/caller.rs
+++ b/src/caller.rs
@@ -1,14 +1,23 @@
+use std::fmt::Debug;
 use super::error::TenoriteError;
 use super::request::TenoriteRequest;
 use tokio::sync::mpsc;
 
 /// Holds the client side handle of the communication
 #[derive(Clone)]
-pub struct TenoriteCaller<Request, Response, Error> {
+pub struct TenoriteCaller<Request, Response, Error>
+    where Request: Debug,
+          Response: Debug,
+          Error: Debug,
+{
     pub handle: mpsc::Sender<TenoriteRequest<Request, Response, Error>>,
 }
 
-impl<Request, Response, Error> TenoriteCaller<Request, Response, Error> {
+impl<Request, Response, Error> TenoriteCaller<Request, Response, Error>
+    where Request: Debug,
+          Response: Debug,
+          Error: Debug,
+{
     /// Sends the request through the underlying caller handle and waits for
     /// the response from the service
     pub async fn send_request(

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,22 @@
+use std::fmt::Debug;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::request::TenoriteRequest;
 
 /// This is the error type returned by [`super::TenoriteCaller::send_request`]
-pub enum TenoriteError<Request, Response, Error> {
+#[derive(thiserror::Error, Debug)]
+pub enum TenoriteError<Request, Response, Error>
+    where Request: Debug,
+          Response: Debug,
+          Error: Debug,
+{
     /// Returned when there is an error sending the request to the service
+    #[error("failed to send request to service: {0}")]
     SendFailure(mpsc::error::SendError<TenoriteRequest<Request, Response, Error>>),
     /// Returned when there is an error fetching the response from the service
+    #[error("failed to fetch response from service: {0}")]
     FetchFailure(oneshot::error::RecvError),
     /// Returned when the service bubbles up an error
+    #[error("service error: {0}")]
     ServiceError(Error),
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,3 +1,4 @@
+use std::fmt::{self, Debug};
 use tokio::sync::oneshot;
 
 /// [`oneshot::Sender`] the service uses to reply to a client
@@ -6,14 +7,32 @@ pub type Responder<Response, Error> = oneshot::Sender<Result<Response, Error>>;
 pub type Respondee<Response, Error> = oneshot::Receiver<Result<Response, Error>>;
 
 /// Encapsulation for requests from client to service
-pub struct TenoriteRequest<Request, Response, Error> {
+pub struct TenoriteRequest<Request, Response, Error>
+    where Request: Debug,
+          Response: Debug,
+          Error: Debug,
+{
     /// Request from the client
     pub request: Request,
     /// Handle used by service to send response
     pub client: Responder<Response, Error>,
 }
 
-impl<Request, Response, Error> TenoriteRequest<Request, Response, Error> {
+impl<Request, Response, Error> Debug for TenoriteRequest<Request, Response, Error>
+    where Request: Debug,
+          Response: Debug,
+          Error: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TenoriteRequest {{ {:?} }}", self.request)
+    }
+}
+
+impl<Request, Response, Error> TenoriteRequest<Request, Response, Error>
+    where Request: Debug,
+          Response: Debug,
+          Error: Debug,
+{
     /// Generates [`oneshot`] channel pair, effectively encoding a callback
     /// handle into the request
     pub fn new(request: Request) -> (Self, Respondee<Response, Error>) {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
@@ -7,9 +8,9 @@ use super::worker::TenoriteWorker;
 /// Binds together the generic type components into the service
 pub trait TenoriteService<Request, Response, Error, Task, TaskConfig>
 where
-    Request: Send + 'static,
-    Response: Send + 'static,
-    Error: Send + 'static,
+    Request: Send + Debug + 'static,
+    Response: Send + Debug + 'static,
+    Error: Send + Debug + 'static,
     Task: TenoriteWorker<Request, Response, Error, TaskConfig>,
     TaskConfig: Send + 'static,
 {

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use async_trait::async_trait;
 use tokio::sync::mpsc::Receiver;
 
@@ -6,7 +7,11 @@ use crate::request::TenoriteRequest;
 /// This trait specifies the worker end of the service. the `task()` method is
 /// what implements the server side logic.
 #[async_trait]
-pub trait TenoriteWorker<Request, Response, Error, TaskConfig> {
+pub trait TenoriteWorker<Request, Response, Error, TaskConfig>
+    where Request: Debug,
+          Response: Debug,
+          Error: Debug,
+{
     /// This task does the work, put your great stuff in here!
     async fn task(
         mut receiver: Receiver<TenoriteRequest<Request, Response, Error>>,


### PR DESCRIPTION
This patch requires Request, Response, and Error parameters to impl the
Debug trait, which allows TenoriteError to impl Debug and Error. By
allowing this, TenoriteError can be used with `.unwrap`, `.expect`, and
error-propagation libraries like `anyhow`.